### PR TITLE
Bugfixes for CurrencyFrame

### DIFF
--- a/modules/CurrencyFrame.lua
+++ b/modules/CurrencyFrame.lua
@@ -123,16 +123,17 @@ do
 		if not index then return end
 		repeat
 			index = index + 1
-			if index > GetCurrencyListSize() then return end
-			CurrencyListInfo = GetCurrencyListInfo(index)
-			if CurrencyListInfo.name then
-				if CurrencyListInfo.isHeader then
-					if not CurrencyListInfo.isHeaderExpanded then
-						tinsert(collapse, 1, index)
-						ExpandCurrencyList(index, true)
+				if index <= GetCurrencyListSize() then
+				CurrencyListInfo = GetCurrencyListInfo(index)
+				if CurrencyListInfo.name then
+					if CurrencyListInfo.isHeader then
+						if not CurrencyListInfo.isHeaderExpanded then
+							tinsert(collapse, 1, index)
+							ExpandCurrencyList(index, true)
+						end
+					else
+						return index, CurrencyListInfo
 					end
-				else
-					return index, CurrencyListInfo
 				end
 			end
 		until index >= GetCurrencyListSize()

--- a/modules/CurrencyFrame.lua
+++ b/modules/CurrencyFrame.lua
@@ -119,27 +119,25 @@ end
 local IterateCurrencies
 do
 	local function iterator(collapse, index)
-		local CurrencyListSize = GetCurrencyListSize()
-		if CurrencyListSize == 0 then return end
-		CurrencyListSize = CurrencyListSize - 2
+		if GetCurrencyListSize() == 0 then return end
 		if not index then return end
 		repeat
 			index = index + 1
-			-- debbugging currency due to blizzard changing the GetCurrency function return
+			if index > GetCurrencyListSize() then return end
 			CurrencyListInfo = GetCurrencyListInfo(index)
 			if CurrencyListInfo.name then
 				if CurrencyListInfo.isHeader then
 					if not CurrencyListInfo.isHeaderExpanded then
 						tinsert(collapse, 1, index)
-						ExpandCurrencyList(index, 1)
+						ExpandCurrencyList(index, true)
 					end
 				else
 					return index, CurrencyListInfo
 				end
 			end
-		until index >= CurrencyListSize
+		until index >= GetCurrencyListSize()
 		for i, index in ipairs(collapse) do
-			ExpandCurrencyList(index, 0)
+			ExpandCurrencyList(index, false)
 		end
 	end
 

--- a/modules/CurrencyFrame.lua
+++ b/modules/CurrencyFrame.lua
@@ -124,7 +124,7 @@ do
 		repeat
 			index = index + 1
 				if index <= GetCurrencyListSize() then
-				CurrencyListInfo = GetCurrencyListInfo(index)
+				local CurrencyListInfo = GetCurrencyListInfo(index)
 				if CurrencyListInfo.name then
 					if CurrencyListInfo.isHeader then
 						if not CurrencyListInfo.isHeaderExpanded then


### PR DESCRIPTION
This was tested on the prepatch. I do not have Shadowlands beta for testing.  This will need to be tested on the Shadowlands beta for compatibility. 

I tested this on a level 20 character that only had 1 currency.  (1 header and 1 currency). C_CurrencyInfo.GetCurrencyListSize returns 2 when the header is expanded.

Fixed 4 bugs with the CurrencyFrame that would prevent currencies from displaying.

bug 1		CurrencyListSize = CurrencyListSize - 2. This skips the last currency in the list.
bug 2		original iterator code iterates past CurrencyListSize when expanding a header. Blizzard API changed to now throw an error when calling GetCurrencyListInfo(index) with an index out of range.
bug 3		caching GetCurrencyListSize() can cause iterating to end prematurely when expanding collapsed headers.
bug 4		ExpandCurrencyList(index, 0) Blizzard API changed. ExpandCurrencyList now wants a boolean value.


I don't fully understand the reasoning for CurrencyListSize = CurrencyListSize - 2.  Removing that line will cause bug 2 to trigger, But keeping it will cause the last currency to be ignored.

Bugs 3 and 4 trigger when you collapse currency headers in the Blizzard Currency UI.